### PR TITLE
Update raffle schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -601,6 +601,8 @@ model Country {
   name     String
   // One-to-Many: A country can have multiple associated products
   products Product[]
+    // One-to-Many: A country can have multiple raffles
+  raffles   Raffle[] @relation("CountryRaffles")
 }
 
 model Brand {
@@ -850,14 +852,21 @@ model Raffle {
   // Timestamp for when the raffle was created
   createdAt   DateTime      @default(now())
   // Timestamp for when the raffle ends
-  endsAt      DateTime
+  endsAt      DateTime?
   // Product associated with the raffle (optional)
   productId   Int?
   // Many-to-One: A raffle is linked to one Product
-  product     Product?       @relation(fields: [productId], references: [id])
+  product     Product?      @relation(fields: [productId], references: [id])
+  // ID of the country (optional, Foreign Key)
+  countryId   Int?          
+  // Many-to-One: A raffle may be linked to one country (optional)
+  country     Country?      @relation("CountryRaffles", fields: [countryId], references: [id])
+  // Indicates if the raffle is worldwide
+  isWorldwide  Boolean       @default(false)
   // One-to-Many: A raffle can have multiple entries
   entries     RaffleEntry[]
 }
+
 
 model RaffleEntry {
   // Unique ID for entry

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -851,10 +851,10 @@ model Raffle {
   createdAt   DateTime      @default(now())
   // Timestamp for when the raffle ends
   endsAt      DateTime
-  // Product associated with the raffle
-  productId   Int
+  // Product associated with the raffle (optional)
+  productId   Int?
   // Many-to-One: A raffle is linked to one Product
-  product     Product       @relation(fields: [productId], references: [id])
+  product     Product?       @relation(fields: [productId], references: [id])
   // One-to-Many: A raffle can have multiple entries
   entries     RaffleEntry[]
 }


### PR DESCRIPTION
## WHAT
- The productId field in the Raffle model is now optional, allowing raffles to be created without requiring an existing product. This is useful for anticipated product releases.
- Raffles can now be designated as worldwide or restricted to specific countries, broadening user participation and catering to regional preferences.
- The endsAt field in the Raffle model has been made optional, accommodating situations where the closing time may not be available during raffle creation.